### PR TITLE
Apply `java` instead of `java-base`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,10 @@ jobs: # a collection of steps
           command: 'echo -en "\n\n\n\n\n\n" | yo dropwizard-gradle'
           shell: /bin/bash
           working_directory: ~/test-application
+          no_output_timeout: 5m
       - run:
           name: build-test-project
           command: './gradlew distZip'
           shell: /bin/bash
           working_directory: ~/test-application
+          no_output_timeout: 5m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,3 @@ jobs: # a collection of steps
           shell: /bin/bash
           working_directory: ~/test-application
           no_output_timeout: 5m
-      - run:
-          name: build-test-project
-          command: './gradlew distZip'
-          shell: /bin/bash
-          working_directory: ~/test-application
-          no_output_timeout: 5m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,4 +33,8 @@ jobs: # a collection of steps
           command: 'echo -en "\n\n\n\n\n\n" | yo dropwizard-gradle'
           shell: /bin/bash
           working_directory: ~/test-application
-          no_output_timeout: 5m
+      - run:
+          name: build-test-project
+          command: './gradlew distZip'
+          shell: /bin/bash
+          working_directory: ~/test-application

--- a/app/templates/build.gradle
+++ b/app/templates/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 // Plugins
 // =======
 apply from: "$rootDir/gradle/repositories.gradle"
-apply plugin: 'java-base'
+apply plugin: 'java'
 apply plugin: 'idea'
 
 // ============


### PR DESCRIPTION
Not sure what the distinction between these two (`java` and `java-base`) is, but I figure we ought to be applying the `java` plugin anyway -- and it mysteriously fixes the problem I was having where I couldn't run the imported gradle project in IDEA.