### PR TITLE
Use newer (and less flaky) git-version Gradle plugin.

### DIFF
--- a/app/templates/build.gradle
+++ b/app/templates/build.gradle
@@ -6,7 +6,6 @@ buildscript {
 
     dependencies {
         classpath "commons-codec:commons-codec:$commonsCodecVersion"
-        classpath "com.palantir:gradle-flexversion:$flexVersion"
         classpath "gradle.plugin.org.inferred:gradle-processors:$gradleProcessorsVersion"
     }
 }
@@ -14,6 +13,10 @@ buildscript {
 // =======
 // Plugins
 // =======
+plugins {
+    id "com.palantir.git-version" version "$gitVersionVersion"
+}
+
 apply from: "$rootDir/gradle/repositories.gradle"
 apply plugin: 'java'
 apply plugin: 'idea'
@@ -25,18 +28,9 @@ repositories {
     mavenCentral()
 }
 
-// ==========
-// Versioning
-// ==========
-apply plugin: 'gradle-flexversion'
-flexversion {
-    useTags = true
-}
-addPrintVersionTask()
-
 allprojects {
     group '<%= package %>'
-    version flexVersion()
+    version gitVersion()
 
     // ============
     // Java Version

--- a/app/templates/gradle.properties
+++ b/app/templates/gradle.properties
@@ -1,7 +1,7 @@
 applicationName=<%= name %>
 commonsCodecVersion=1.9
 dropwizardVersion=1.3.5
-flexVersion=0.9.0
+gitVersionVersion=0.12.2
 jreMinorVersion = 11
 postgresqlVersion=42.2.8.jre7
 wrapperVersion=3.2.3


### PR DESCRIPTION
Replace https://github.com/palantir/gradle-flexversion with https://github.com/palantir/gradle-git-version, as the former is no longer maintained.